### PR TITLE
Fix deprecation warnings about Fixnum for Ruby >= 2.4

### DIFF
--- a/lib/kashmir/representation.rb
+++ b/lib/kashmir/representation.rb
@@ -111,7 +111,13 @@ module Kashmir
     end
 
     def primitive?(field_value)
-      [Fixnum, String, Date, Time, TrueClass, FalseClass, Symbol].any? do |type|
+      primitives = [String, Date, Time, TrueClass, FalseClass, Symbol]
+      primitives << if RUBY_VERSION > '2.4'
+        Integer
+      else
+        Fixnum
+      end
+      primitives.any? do |type|
         field_value.is_a?(type)
       end
     end

--- a/lib/kashmir/representation.rb
+++ b/lib/kashmir/representation.rb
@@ -112,7 +112,7 @@ module Kashmir
 
     def primitive?(field_value)
       primitives = [String, Date, Time, TrueClass, FalseClass, Symbol]
-      primitives << if RUBY_VERSION > '2.4'
+      primitives << if RUBY_VERSION >= '2.4'
         Integer
       else
         Fixnum


### PR DESCRIPTION
This should resolve #12 

Usage example

```
git clone https://github.com/mbigras/kashmir
cd kashmir/
git co a90f15d6c44564dde644e26ae848374b68a09273
bundle install
ruby --version
# ruby 2.4.2p198 (2017-09-14 revision 59899) [x86_64-darwin16]
bundle exec ruby <<'EOF'
require 'kashmir'
class Person
  include Kashmir
  
  def initialize(name, age)
    @name = name
    @age = age
  end
  
  representations do
    rep :name
    rep :age
  end
end
p Person.new('Netto Farah', 26).represent([:name, :age])
EOF
# {:name=>"Netto Farah", :age=>26}
```
